### PR TITLE
Integrate pandoc

### DIFF
--- a/bin/run-tests
+++ b/bin/run-tests
@@ -10,6 +10,7 @@ cabal build -O0 --enable-tests --ghc-option=-Werror all
 
 log "Testing"
 cabal test -O0 --test-show-details=direct
+cabal test -O0 --test-option=--accept --test-show-details=direct test:md2jira-test
 cabal check
 
 log "Formatting"

--- a/flake.lock
+++ b/flake.lock
@@ -5,33 +5,33 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1681261331,
-        "narHash": "sha256-FFF4qeSOieKl3s5h6bpR5Tllz7aqSaF+pE5bkg+BSfM=",
+        "lastModified": 1722898016,
+        "narHash": "sha256-LiaOVYgJsaKWPxF14z7NtLBwrr8L20LNIHn/7VFgVfQ=",
         "owner": "podenv",
         "repo": "hspkgs",
-        "rev": "90eadd304c6375f926a0970f87b470e765e7f176",
+        "rev": "7a46854f28ab9b99c51353c81d5967f1f6fd9a9b",
         "type": "github"
       },
       "original": {
         "owner": "podenv",
         "repo": "hspkgs",
-        "rev": "90eadd304c6375f926a0970f87b470e765e7f176",
+        "rev": "7a46854f28ab9b99c51353c81d5967f1f6fd9a9b",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672755833,
-        "narHash": "sha256-AmPzlvY1Y5codnytZCDn2wlhVa8rDHNib5wBWtcD7c4=",
+        "lastModified": 1721952842,
+        "narHash": "sha256-B6Fm/e+2Iq1LB0ITtdaVS/lxkckCwPNpgBuduuv1HzY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3665c429d349fbda46b0651e554cca8434452748",
+        "rev": "574f1a6205e63e9870c6e6132c393f9082d58d2a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3665c429d349fbda46b0651e554cca8434452748",
+        "rev": "574f1a6205e63e9870c6e6132c393f9082d58d2a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     hspkgs.url =
-      "github:podenv/hspkgs/90eadd304c6375f926a0970f87b470e765e7f176";
+      "github:podenv/hspkgs/7a46854f28ab9b99c51353c81d5967f1f6fd9a9b";
     # "path:///srv/github.com/podenv/hspkgs";
   };
   outputs = { self, hspkgs }:
@@ -15,10 +15,10 @@
       hsPkgs = pkgs.hspkgs.extend haskellExtend;
 
       baseTools = with pkgs; [
+        cabal-gild
         hpack
         cabal-install
         hlint
-        tasty-discover
         fourmolu
         weeder
         hsPkgs.doctest
@@ -30,12 +30,8 @@
         buildInputs = baseTools;
       };
       devShell."x86_64-linux" = hsPkgs.shellFor {
-        packages = p: [ p.jira-client p.md2jira];
-        buildInputs = with pkgs;
-          [
-            ghcid
-            haskell-language-server
-          ] ++ baseTools;
+        packages = p: [ p.jira-client p.md2jira ];
+        buildInputs = with pkgs; [ ghcid haskell-language-server ] ++ baseTools;
       };
     };
 }

--- a/md2jira/README.md
+++ b/md2jira/README.md
@@ -49,18 +49,18 @@ Refine the entry and run `md2jira project.md` to create the issues in Jira.
 The tool will update the file to inject the remote identifiers:
 
 ```markdown
-# PROJ-1 Develop Y
+# Develop Y {#PROJ-1}
 
-## PROJ-2 Implement feature name
+## Implement feature name {#PROJ-2}
 
 The goal of this story is to ...:
 
 - [ ] create module
 - [ ] update api
 
-# PROJ-3 Operate X
+# Operate X {#PROJ-3}
 
-# PROJ-4 Support Z
+# Support Z {#PROJ-4}
 ```
 
 Re-run `md2jira` at any points to synchronize the file content, the command is idempotent.
@@ -72,8 +72,8 @@ The tool perform one-way push synchronization: the Jira data is not pulled.
 Define what needs to be done next by marking the actionable items:
 
 ```markdown
-- [.] a task to be completed next
-- [TC] a task in progress assigned to TC
+- [ ] a task to be completed next {.n}
+- [ ] a task in progress assigned to {.TC}
 ```
 
 **Do the work**
@@ -81,8 +81,8 @@ Define what needs to be done next by marking the actionable items:
 Once a task is complete, mark the the item and add a comment:
 
 ```markdown
-- [x] a completed task
-  TC: here is the $change_url
+- [x] a completed task {.TC}
+  > here is the $change_url
 ```
 
 Once all the tasks are done, run `md2jira` one more time to close the story.

--- a/md2jira/app/Migrate.hs
+++ b/md2jira/app/Migrate.hs
@@ -1,0 +1,39 @@
+-- | A script to migrate backlog file from megaparsec to pandoc
+module Migrate where
+
+import Data.List
+import GHC.Read
+
+main :: IO ()
+main = interact (unlines . go [] . lines)
+
+go :: [String] -> [String] -> [String]
+go acc [] = reverse acc
+go acc (x : xs)
+    | -- An epic line: move the jid to a {#} attribute
+      "# " `isPrefixOf` x
+    , Just (jid, line) <- parseJID (drop 2 x) =
+        go (("# " <> line <> " {#" <> jid <> "}") : acc) xs
+    | -- A story line: move the jid and add the score from the next line
+      "## " `isPrefixOf` x
+    , Just (jid, line) <- parseJID (drop 3 x) =
+        let (score, rest) = case xs of
+                (next : xs') | "> Score: " `isPrefixOf` next -> (" score=" <> drop 9 next, xs')
+                _ -> ("", xs)
+         in go (("## " <> line <> " {#" <> jid <> score <> "}") : acc) rest
+    | -- A task line: move the '.' and assigned to a {.} attribute
+      "- [" `isPrefixOf` x =
+        let line = drop 3 x
+            status = takeWhile (/= ']') line
+            task = dropWhile (== ' ') $ drop (1 + length status) line
+            (newStatus, tag) = case status of
+                "." -> (" ", " {.n}")
+                s | s `elem` [" ", "x"] -> (s, "")
+                name -> (" ", " {." <> name <> "}")
+         in go (("- [" <> newStatus <> "] " <> task <> tag) : acc) xs
+    | otherwise = go (x : acc) xs
+
+parseJID :: String -> Maybe (String, String)
+parseJID s = case lex s of
+    [(proj, '-' : num)] | [(n, ' ' : rest)] <- lexDigits num -> Just (proj <> "-" <> n, dropWhile (== ' ') rest)
+    _ -> Nothing

--- a/md2jira/md2jira.cabal
+++ b/md2jira/md2jira.cabal
@@ -1,6 +1,10 @@
 cabal-version: 2.2
 name: md2jira
 version:        0.1
+extra-source-files:
+  test/golden/*.golden
+  test/golden/*.md
+
 
 common common
   build-depends:      base <5
@@ -25,7 +29,8 @@ library
   exposed-modules: MD2Jira
   build-depends:
     , aeson
-    , megaparsec
+    , pandoc
+    , pandoc-types
     , containers
     , exceptions
     , transformers
@@ -33,6 +38,7 @@ library
     , jira-client
     , mtl
     , text
+    , unix-time
     , witch
 
 executable md2jira
@@ -47,3 +53,17 @@ executable md2jira
     , bytestring
     , jira-client
     , http-client-tls
+
+test-suite md2jira-test
+  import: common, executable
+  type: exitcode-stdio-1.0
+  build-depends:
+    , text
+    , directory
+    , pretty-simple  <5
+    , tasty          <1.5
+    , tasty-golden   <2.4
+    , tasty-hunit    <0.11
+    , md2jira
+  hs-source-dirs: test
+  main-is: Spec.hs

--- a/md2jira/test/Spec.hs
+++ b/md2jira/test/Spec.hs
@@ -1,0 +1,62 @@
+module Main (main) where
+
+import Data.List (isSuffixOf)
+import Data.Text.IO qualified as T
+import Data.Text.Lazy qualified as LText
+import Data.Text.Lazy.Builder qualified as T
+import Data.Text.Lazy.Encoding qualified as LText
+import MD2Jira qualified
+import System.Directory (listDirectory)
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.Golden (goldenVsString)
+import Text.Pretty.Simple (pShowNoColor)
+
+main :: IO ()
+main = do
+    goldenFiles <- traverse parseMD =<< listGoldenFiles
+    defaultMain $
+        testGroup
+            "Tests"
+            [ testGroup "Golden test" $ map doGoldenTest goldenFiles
+            ]
+
+listGoldenFiles :: IO [FilePath]
+listGoldenFiles = map (mappend dpath) . filter (not . isSuffixOf ".golden") <$> listDirectory dpath
+  where
+    dpath = "test/golden/"
+
+parseMD :: FilePath -> IO (FilePath, MD2Jira.Document)
+parseMD fp = do
+    inp <- T.readFile fp
+    case MD2Jira.parse inp of
+        Left e -> error (show e)
+        Right x -> pure (fp, x)
+
+doGoldenTest :: (FilePath, MD2Jira.Document) -> TestTree
+doGoldenTest (fp, doc) =
+    testGroup
+        fp
+        [ go "ast" (pShowNoColor doc)
+        , go "round" (LText.fromStrict $ MD2Jira.printer doc)
+        , go "jira" (T.toLazyText $ foldMap jiraDoc doc.epics)
+        ]
+  where
+    jiraDoc :: MD2Jira.Epic -> T.Builder
+    jiraDoc epic =
+        mconcat
+            [ "EpicTitle: "
+            , T.fromText epic.title
+            , "\nEpicBody:\n"
+            , T.fromText $ MD2Jira.toJira epic.description
+            , foldMap jiraStoryDoc epic.stories
+            , "\n"
+            ]
+    jiraStoryDoc story =
+        mconcat
+            [ "\n\nStoryTitle: "
+            , T.fromText story.title
+            , "\nStoryBody:\n"
+            , T.fromText $ MD2Jira.toJira story.description
+            , "\n"
+            ]
+    go name out = goldenVsString name (fp <> "-" <> name <> ".golden") (pure $ LText.encodeUtf8 out)

--- a/md2jira/test/golden/attr.md
+++ b/md2jira/test/golden/attr.md
@@ -1,0 +1,6 @@
+# epic
+
+## story {#P-4 score=42 updated=2024-09-07}
+
+- [ ] task {.end}
+note

--- a/md2jira/test/golden/attr.md-ast.golden
+++ b/md2jira/test/golden/attr.md-ast.golden
@@ -1,0 +1,47 @@
+Document
+    { intro = []
+    , epics =
+        [ Epic
+            { mJira = Nothing
+            , title = "epic"
+            , description = []
+            , stories =
+                [ Story
+                    { mJira = Just "P-4"
+                    , title = "story"
+                    , description =
+                        [ BulletList
+                            [
+                                [ Plain
+                                    [ Str "☐"
+                                    , Space
+                                    , Str "task"
+                                    , Span
+                                        ( ""
+                                        , [ "end" ]
+                                        , []
+                                        ) [ Space ]
+                                    , SoftBreak
+                                    , Str "note"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    , tasks =
+                        [ Task
+                            { status = Open
+                            , title = "task"
+                            , assigned = [ "end" ]
+                            , description =
+                                [ Plain
+                                    [ Str "note" ]
+                                ]
+                            }
+                        ]
+                    , mScore = Just 42.0
+                    , updated = Just 1725667200
+                    }
+                ]
+            }
+        ]
+    }

--- a/md2jira/test/golden/attr.md-jira.golden
+++ b/md2jira/test/golden/attr.md-jira.golden
@@ -1,0 +1,10 @@
+EpicTitle: epic
+EpicBody:
+
+
+StoryTitle: story
+StoryBody:
+* ☐ task
+note
+
+

--- a/md2jira/test/golden/attr.md-round.golden
+++ b/md2jira/test/golden/attr.md-round.golden
@@ -1,0 +1,6 @@
+# epic
+
+## story {#P-4 score="42" updated="2024-09-07"}
+
+- [ ] task {.end}
+  note

--- a/md2jira/test/golden/demo.md
+++ b/md2jira/test/golden/demo.md
@@ -1,0 +1,33 @@
+---
+title: Team backlog
+---
+
+Document usage:
+- test
+
+# Develop app  {#PROJ-42}
+
+The goal of app is ...
+
+```bash
+$ command
+output
+```
+
+## Implement X
+
+The goal of this story is ...
+
+- [ ] do x {.n}
+- [ ] and y
+
+what about:
+
+- [ ] z task
+
+## Implement Z
+
+- [x] completed {.tc}
+  > https://localhost
+
+- [ ] todo

--- a/md2jira/test/golden/demo.md-ast.golden
+++ b/md2jira/test/golden/demo.md-ast.golden
@@ -1,0 +1,182 @@
+Document
+    { intro =
+        [ Para
+            [ Str "Document"
+            , Space
+            , Str "usage:"
+            ]
+        , BulletList
+            [
+                [ Plain
+                    [ Str "test" ]
+                ]
+            ]
+        ]
+    , epics =
+        [ Epic
+            { mJira = Just "PROJ-42"
+            , title = "Develop app"
+            , description =
+                [ Para
+                    [ Str "The"
+                    , Space
+                    , Str "goal"
+                    , Space
+                    , Str "of"
+                    , Space
+                    , Str "app"
+                    , Space
+                    , Str "is"
+                    , Space
+                    , Str "..."
+                    ]
+                , CodeBlock
+                    ( ""
+                    , [ "bash" ]
+                    , []
+                    ) "$ command
+                  output"
+                ]
+            , stories =
+                [ Story
+                    { mJira = Nothing
+                    , title = "Implement X"
+                    , description =
+                        [ Para
+                            [ Str "The"
+                            , Space
+                            , Str "goal"
+                            , Space
+                            , Str "of"
+                            , Space
+                            , Str "this"
+                            , Space
+                            , Str "story"
+                            , Space
+                            , Str "is"
+                            , Space
+                            , Str "..."
+                            ]
+                        , BulletList
+                            [
+                                [ Plain
+                                    [ Str "☐"
+                                    , Space
+                                    , Str "do"
+                                    , Space
+                                    , Str "x"
+                                    , Span
+                                        ( ""
+                                        , [ "n" ]
+                                        , []
+                                        ) [ Space ]
+                                    ]
+                                ]
+                            ,
+                                [ Plain
+                                    [ Str "☐"
+                                    , Space
+                                    , Str "and"
+                                    , Space
+                                    , Str "y"
+                                    ]
+                                ]
+                            ]
+                        , Para
+                            [ Str "what"
+                            , Space
+                            , Str "about:"
+                            ]
+                        , BulletList
+                            [
+                                [ Plain
+                                    [ Str "☐"
+                                    , Space
+                                    , Str "z"
+                                    , Space
+                                    , Str "task"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    , tasks =
+                        [ Task
+                            { status = Open
+                            , title = "do x"
+                            , assigned = [ "n" ]
+                            , description =
+                                [ Plain [] ]
+                            }
+                        , Task
+                            { status = Open
+                            , title = "and y"
+                            , assigned = []
+                            , description = []
+                            }
+                        , Task
+                            { status = Open
+                            , title = "z task"
+                            , assigned = []
+                            , description = []
+                            }
+                        ]
+                    , mScore = Nothing
+                    , updated = Nothing
+                    }
+                , Story
+                    { mJira = Nothing
+                    , title = "Implement Z"
+                    , description =
+                        [ BulletList
+                            [
+                                [ Para
+                                    [ Str "☒"
+                                    , Space
+                                    , Str "completed"
+                                    , Span
+                                        ( ""
+                                        , [ "tc" ]
+                                        , []
+                                        ) [ Space ]
+                                    ]
+                                , BlockQuote
+                                    [ Para
+                                        [ Str "https://localhost" ]
+                                    ]
+                                ]
+                            ,
+                                [ Para
+                                    [ Str "☐"
+                                    , Space
+                                    , Str "todo"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    , tasks =
+                        [ Task
+                            { status = Closed
+                            , title = "completed"
+                            , assigned = [ "tc" ]
+                            , description =
+                                [ Plain []
+                                , BlockQuote
+                                    [ Para
+                                        [ Str "https://localhost" ]
+                                    ]
+                                ]
+                            }
+                        , Task
+                            { status = Open
+                            , title = "todo"
+                            , assigned = []
+                            , description = []
+                            }
+                        ]
+                    , mScore = Nothing
+                    , updated = Nothing
+                    }
+                ]
+            }
+        ]
+    }

--- a/md2jira/test/golden/demo.md-jira.golden
+++ b/md2jira/test/golden/demo.md-jira.golden
@@ -1,0 +1,29 @@
+EpicTitle: Develop app
+EpicBody:
+The goal of app is ...
+
+{code:bash}
+$ command
+output
+{code}
+
+StoryTitle: Implement X
+StoryBody:
+The goal of this story is ...
+
+* ☐ do x
+* ☐ and y
+
+what about:
+
+* ☐ z task
+
+
+
+StoryTitle: Implement Z
+StoryBody:
+* ☒ completed
+bq. https://localhost
+* ☐ todo
+
+

--- a/md2jira/test/golden/demo.md-round.golden
+++ b/md2jira/test/golden/demo.md-round.golden
@@ -1,0 +1,31 @@
+Document usage:
+
+- test
+
+# Develop app {#PROJ-42}
+
+The goal of app is ...
+
+``` bash
+$ command
+output
+```
+
+## Implement X
+
+The goal of this story is ...
+
+- [ ] do x {.n}
+- [ ] and y
+
+what about:
+
+- [ ] z task
+
+## Implement Z
+
+- [x] completed {.tc}
+
+  > https://localhost
+
+- [ ] todo

--- a/md2jira/test/golden/tasks.md
+++ b/md2jira/test/golden/tasks.md
@@ -1,0 +1,16 @@
+# epic
+## story
+
+- [ ] a task
+with left over
+
+- [ ] a task
+  with right
+
+> with quote?
+
+- [ ] a task
+> with comment
+
+- [ ] a task
+  > with comment

--- a/md2jira/test/golden/tasks.md-ast.golden
+++ b/md2jira/test/golden/tasks.md-ast.golden
@@ -1,0 +1,133 @@
+Document
+    { intro = []
+    , epics =
+        [ Epic
+            { mJira = Nothing
+            , title = "epic"
+            , description = []
+            , stories =
+                [ Story
+                    { mJira = Nothing
+                    , title = "story"
+                    , description =
+                        [ BulletList
+                            [
+                                [ Para
+                                    [ Str "☐"
+                                    , Space
+                                    , Str "a"
+                                    , Space
+                                    , Str "task"
+                                    , SoftBreak
+                                    , Str "with"
+                                    , Space
+                                    , Str "left"
+                                    , Space
+                                    , Str "over"
+                                    ]
+                                ]
+                            ,
+                                [ Para
+                                    [ Str "☐"
+                                    , Space
+                                    , Str "a"
+                                    , Space
+                                    , Str "task"
+                                    , SoftBreak
+                                    , Str "with"
+                                    , Space
+                                    , Str "right"
+                                    ]
+                                ]
+                            ]
+                        , BlockQuote
+                            [ Para
+                                [ Str "with"
+                                , Space
+                                , Str "quote?"
+                                ]
+                            ]
+                        , BulletList
+                            [
+                                [ Plain
+                                    [ Str "☐"
+                                    , Space
+                                    , Str "a"
+                                    , Space
+                                    , Str "task"
+                                    ]
+                                ]
+                            ]
+                        , BlockQuote
+                            [ Para
+                                [ Str "with"
+                                , Space
+                                , Str "comment"
+                                ]
+                            ]
+                        , BulletList
+                            [
+                                [ Plain
+                                    [ Str "☐"
+                                    , Space
+                                    , Str "a"
+                                    , Space
+                                    , Str "task"
+                                    ]
+                                , BlockQuote
+                                    [ Para
+                                        [ Str "with"
+                                        , Space
+                                        , Str "comment"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    , tasks =
+                        [ Task
+                            { status = Open
+                            , title = "a task"
+                            , assigned = []
+                            , description =
+                                [ Plain
+                                    [ Str "with"
+                                    , Space
+                                    , Str "left"
+                                    , Space
+                                    , Str "over"
+                                    ]
+                                ]
+                            }
+                        , Task
+                            { status = Open
+                            , title = "a task"
+                            , assigned = []
+                            , description =
+                                [ Plain
+                                    [ Str "with"
+                                    , Space
+                                    , Str "right"
+                                    ]
+                                ]
+                            }
+                        , Task
+                            { status = Open
+                            , title = "a task"
+                            , assigned = []
+                            , description = []
+                            }
+                        , Task
+                            { status = Open
+                            , title = "a task"
+                            , assigned = []
+                            , description = []
+                            }
+                        ]
+                    , mScore = Nothing
+                    , updated = Nothing
+                    }
+                ]
+            }
+        ]
+    }

--- a/md2jira/test/golden/tasks.md-jira.golden
+++ b/md2jira/test/golden/tasks.md-jira.golden
@@ -1,0 +1,19 @@
+EpicTitle: epic
+EpicBody:
+
+
+StoryTitle: story
+StoryBody:
+* ☐ a task
+with left over
+* ☐ a task
+with right
+
+bq. with quote?
+* ☐ a task
+
+bq. with comment
+* ☐ a task
+bq. with comment
+
+

--- a/md2jira/test/golden/tasks.md-round.golden
+++ b/md2jira/test/golden/tasks.md-round.golden
@@ -1,0 +1,18 @@
+# epic
+
+## story
+
+- [ ] a task
+  with left over
+
+- [ ] a task
+  with right
+
+> with quote?
+
+- [ ] a task
+
+> with comment
+
+- [ ] a task
+  > with comment

--- a/src/Jira.hs
+++ b/src/Jira.hs
@@ -212,7 +212,9 @@ searchIssuesInfo = searchIssuesImpl decodeIssueInfo []
 searchIssues :: JiraClient -> JiraSearchRequest -> IO (Either Text (JiraSearchResult JiraIssue))
 searchIssues client = searchIssuesImpl (decodeIssue client) [String "project", String "issuetype", String "description", String "summary", String $ Key.toText client.issueScoreKey] client
 
-newtype Transition = Transition Word deriving newtype (Eq, Show, ToJSON, FromJSON)
+newtype Transition = Transition Word
+    deriving (Generic)
+    deriving newtype (Eq, Show, ToJSON, FromJSON)
 
 data IssueType = Epic | EpicStory JiraID | Story | SubTask JiraID
     deriving (Show)


### PR DESCRIPTION
This change replaces the custom markdown parser using pandoc so that the jira content can be formated using the proper markup.

This change also leverages the markdown attribute syntax to record the necessary metadata: `{#ID .class key=value}`

The main difference is that the task assignments are now defined as a span attribute like this:

Before:

```markdown
- [.] a next task
- [TC] an assigned task
```
After:

```markdown
- [ ] a next task {.n}
- [ ] an assigned task {.TC}
```

The reason is to respect the task list syntax, e.g. `[.]` is not valid and it was not displayed well.