### PR TITLE
Reduce the  MD2Jira scope and support local cache update

### DIFF
--- a/md2jira/README.md
+++ b/md2jira/README.md
@@ -67,31 +67,13 @@ Re-run `md2jira` at any points to synchronize the file content, the command is i
 An entry without an identifier will be created, otherwise it is updated.
 The tool perform one-way push synchronization: the Jira data is not pulled.
 
-**Plan the work**
-
-Define what needs to be done next by marking the actionable items:
-
-```markdown
-- [ ] a task to be completed next {.n}
-- [ ] a task in progress assigned to {.TC}
-```
-
-**Do the work**
-
-Once a task is complete, mark the the item and add a comment:
-
-```markdown
-- [x] a completed task {.TC}
-  > here is the $change_url
-```
-
 Once all the tasks are done, run `md2jira` one more time to close the story.
 Then the story can be removed from the file and added to a separate `archive.md`.
 
 
 ## Usage
 
-Get the toolchain using [ghcup](https://www.haskell.org/ghcup/) and install the command line to `~/.cabal/bin`:
+Get the toolchain using [ghcup](https://www.haskell.org/ghcup/) and install the command line:
 
 ```
 $ cabal install --installdir=~/.local/bin exe:md2jira
@@ -119,25 +101,12 @@ $ cabal run exe:md2jira -- --help
 ```
 
 
-## Integration with etherpad
-
-Here is a one-liner to maintain your backlog in etherpad:
-
-```
-$ curl https://etherpad.example.com/project-backlog/export/txt | md2jira > update.md \
- && curl "http://etherpad.example.com/api/1/setText?apikey=$PAD_TOKEN&padID=project-backlog" \
-    --data-urlencode "text=$(cat update.md)"
-```
-
 ## Contribute
 
 Feel free to report issues and propose new features. Run the `./bin/run-tests` at the top of the project to validate your changes.
 
 Roadmap:
 
-- [x] Handle story status, e.g. no `[x]` means open, one tick means in-progress, all-ticked means completed.
-- [ ] Implement a `--list` command to list the planned and completed tasks with their links to their stories.
-- [ ] Support custom transition (see 'taskTransition').
-- [ ] Support sub-task, e.g. with `###` third heading
+- [ ] Support story status
 - [ ] Manage assignment, e.g. by adding user-id after the heading
-- [x] Provide a custom editor with quill-ot to handle outline folding (see: [butler#61](https://github.com/ButlerOS/haskell-butler/pull/61))
+- [ ] Support sub-task, e.g. with `###` third heading

--- a/md2jira/README.md
+++ b/md2jira/README.md
@@ -107,6 +107,6 @@ Feel free to report issues and propose new features. Run the `./bin/run-tests` a
 
 Roadmap:
 
-- [ ] Support story status
+- [x] Support story status
 - [ ] Manage assignment, e.g. by adding user-id after the heading
 - [ ] Support sub-task, e.g. with `###` third heading

--- a/md2jira/README.md
+++ b/md2jira/README.md
@@ -1,8 +1,9 @@
 # md2jira - Manage Jira Backlog In Markdown
 
-Use this tool to push your tasks written in markdown to JIRA.
+Use this tool to push your backlog written in markdown to JIRA.
 
-## Suggested Workflow
+
+## Usage
 
 **Create a `project.md` file**
 
@@ -42,9 +43,10 @@ The goal of this story is to ...:
 # Support Z
 ```
 
+
 **Synchronize to Jira**
 
-Refine the entry and run `md2jira project.md` to create the issues in Jira.
+Run `md2jira project.md` to create the backlog in Jira.
 
 The tool will update the file to inject the remote identifiers:
 
@@ -63,20 +65,58 @@ The goal of this story is to ...:
 # Support Z {#PROJ-4}
 ```
 
-Re-run `md2jira` at any points to synchronize the file content, the command is idempotent.
 An entry without an identifier will be created, otherwise it is updated.
 The tool perform one-way push synchronization: the Jira data is not pulled.
 
-Once all the tasks are done, run `md2jira` one more time to close the story.
-Then the story can be removed from the file and added to a separate `archive.md`.
+> ![tip]
+> Re-run `md2jira` at any points to synchronize the file content, the command is idempotent.
+
+**Update Status**
+
+When one of the following attribute is defined, then `md2jira` will set the status in Jira:
+
+- **status**: one of todo/wip/done
+- **points**: a number
+- **assignee**: a nickname
+
+The assignee nicknames must be defined in the file frontmater. Here is an example:
+
+```markdown
+---
+users:
+  tc: tdecacqu@redhat.com
+---
+# Develop Y {#PROJ-1}
+
+## Implement feature name {#PROJ-2 status=done points=5 assignee=tc}
+
+The goal of this story is to ...:
+
+- [x] create module
+- [x] update api
+```
+
+The attributes that are not defined in the markdown file are not updated in Jira.
+
+> ![note]
+> A story is always attached to a parent epic.
+> To manage a flat list of stories without creating an epic,
+> named the top level heading: `# Stories without epic`
 
 
-## Usage
+## Install
 
-Get the toolchain using [ghcup](https://www.haskell.org/ghcup/) and install the command line:
+Get the toolchain using [ghcup](https://www.haskell.org/ghcup/) and download the source:
+
+```bash
+git clone https://github.com/ButlerOS/haskell-jira-client
+cd haskell-jiira-client
+```
+
+Build and install the command line to `~/.cabal/bin`
 
 ```
-$ cabal install --installdir=~/.local/bin exe:md2jira
+$ cabal install exe:md2jira
 ```
 
 Write an environment `.env`:
@@ -90,11 +130,11 @@ JIRA_TOKEN=Msecret
 Run the tool:
 
 ```
-$ export $(cat .env)
-$ md2jira project.md
+$ export $(cat .env) PATH="${HOME}/.cabal/bin:${PATH}"
+$ md2jira --dry < project.md
 ```
 
-Alternatively, run the tool from the sources using:
+Alternatively, run the tool directly from the sources using:
 
 ```
 $ cabal run exe:md2jira -- --help
@@ -107,6 +147,6 @@ Feel free to report issues and propose new features. Run the `./bin/run-tests` a
 
 Roadmap:
 
-- [x] Support story status
-- [ ] Manage assignment, e.g. by adding user-id after the heading
-- [ ] Support sub-task, e.g. with `###` third heading
+- [ ] Update the epic link when a story is moved to a different epic.
+- [ ] Mark a story has completed if all the tasks are closed (prefixed by `- [x] `)
+- [ ] Support sub-task, e.g. with `###` third heading.

--- a/md2jira/md2jira.cabal
+++ b/md2jira/md2jira.cabal
@@ -41,6 +41,7 @@ library
     , text
     , unix-time
     , witch
+    , yaml
 
 executable md2jira
   import:         common, executable

--- a/md2jira/src/MD2Jira.hs
+++ b/md2jira/src/MD2Jira.hs
@@ -20,7 +20,6 @@ import Data.Aeson (FromJSON, ToJSON)
 import Data.Char (isAsciiUpper)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
@@ -190,7 +189,7 @@ parseStories acc (x : rest) = case x of
 
 -- | Convert a pandoc definitions into a jira markup
 toJira :: [P.Block] -> Text
-toJira blocks = case P.runPure (P.writeJira writerOpt (P.Pandoc mempty body)) of
+toJira blocks = T.stripEnd $ case P.runPure (P.writeJira writerOpt (P.Pandoc mempty body)) of
     Left err -> P.renderError err
     Right txt -> txt
   where
@@ -297,7 +296,7 @@ issueToData :: Jira.JiraIssue -> Jira.IssueData
 issueToData issue =
     Jira.IssueData
         { summary = issue.summary
-        , description = fromMaybe "" issue.description
+        , description = maybe mempty T.stripEnd issue.description
         , assignee = issue.assignee
         }
 

--- a/md2jira/test/golden/attr.md
+++ b/md2jira/test/golden/attr.md
@@ -1,6 +1,6 @@
 # epic
 
-## story {#P-4 score=42 updated=2024-09-07, prio=H}
+## story {#P-4 points=42 updated=2024-09-07}
 
 - [ ] task {.end}
 note

--- a/md2jira/test/golden/attr.md-ast.golden
+++ b/md2jira/test/golden/attr.md-ast.golden
@@ -1,5 +1,5 @@
 Document
-    { kind = FullBacklog
+    { config = EmptyConfig
     , intro = []
     , epics =
         [ Epic
@@ -10,7 +10,6 @@ Document
                 [ Story
                     { mJira = Just "P-4"
                     , title = "story"
-                    , assigned = []
                     , description =
                         [ BulletList
                             [
@@ -29,20 +28,8 @@ Document
                                 ]
                             ]
                         ]
-                    , tasks =
-                        [ Task
-                            { status = Open
-                            , title = "task"
-                            , assigned = [ "end" ]
-                            , description =
-                                [ Plain
-                                    [ Str "note" ]
-                                ]
-                            }
-                        ]
                     , mScore = Just 42.0
                     , updated = Just 1725667200
-                    , priority = Just High
                     }
                 ]
             }

--- a/md2jira/test/golden/attr.md-ast.golden
+++ b/md2jira/test/golden/attr.md-ast.golden
@@ -1,5 +1,5 @@
 Document
-    { config = EmptyConfig
+    { config = DocumentConfig { users = Nothing }
     , intro = []
     , epics =
         [ Epic
@@ -29,6 +29,7 @@ Document
                                 ]
                             ]
                         ]
+                    , assignee = Nothing
                     , points = Just 42.0
                     , updated = Just 1725667200
                     }

--- a/md2jira/test/golden/attr.md-ast.golden
+++ b/md2jira/test/golden/attr.md-ast.golden
@@ -10,6 +10,7 @@ Document
                 [ Story
                     { mJira = Just "P-4"
                     , title = "story"
+                    , status = Nothing
                     , description =
                         [ BulletList
                             [
@@ -28,7 +29,7 @@ Document
                                 ]
                             ]
                         ]
-                    , mScore = Just 42.0
+                    , points = Just 42.0
                     , updated = Just 1725667200
                     }
                 ]

--- a/md2jira/test/golden/attr.md-jira.golden
+++ b/md2jira/test/golden/attr.md-jira.golden
@@ -7,4 +7,3 @@ StoryBody:
 * ☐ task
 note
 
-

--- a/md2jira/test/golden/attr.md-round.golden
+++ b/md2jira/test/golden/attr.md-round.golden
@@ -1,6 +1,6 @@
 # epic
 
-## story {#P-4 score="42" updated="2024-09-07" prio="H"}
+## story {#P-4 score="42" updated="2024-09-07"}
 
 - [ ] task {.end}
   note

--- a/md2jira/test/golden/attr.md-round.golden
+++ b/md2jira/test/golden/attr.md-round.golden
@@ -1,6 +1,6 @@
 # epic
 
-## story {#P-4 score="42" updated="2024-09-07"}
+## story {#P-4 points="42" updated="2024-09-07"}
 
 - [ ] task {.end}
   note

--- a/md2jira/test/golden/demo.md-ast.golden
+++ b/md2jira/test/golden/demo.md-ast.golden
@@ -1,5 +1,5 @@
 Document
-    { kind = FullBacklog
+    { config = EmptyConfig
     , intro =
         [ Para
             [ Str "Document"
@@ -42,7 +42,6 @@ Document
                 [ Story
                     { mJira = Nothing
                     , title = "Implement X"
-                    , assigned = []
                     , description =
                         [ Para
                             [ Str "The"
@@ -101,35 +100,12 @@ Document
                                 ]
                             ]
                         ]
-                    , tasks =
-                        [ Task
-                            { status = Open
-                            , title = "do x"
-                            , assigned = [ "n" ]
-                            , description =
-                                [ Plain [] ]
-                            }
-                        , Task
-                            { status = Open
-                            , title = "and y"
-                            , assigned = []
-                            , description = []
-                            }
-                        , Task
-                            { status = Open
-                            , title = "z task"
-                            , assigned = []
-                            , description = []
-                            }
-                        ]
                     , mScore = Nothing
                     , updated = Nothing
-                    , priority = Nothing
                     }
                 , Story
                     { mJira = Nothing
                     , title = "Implement Z"
-                    , assigned = []
                     , description =
                         [ BulletList
                             [
@@ -157,29 +133,8 @@ Document
                                 ]
                             ]
                         ]
-                    , tasks =
-                        [ Task
-                            { status = Closed
-                            , title = "completed"
-                            , assigned = [ "tc" ]
-                            , description =
-                                [ Plain []
-                                , BlockQuote
-                                    [ Para
-                                        [ Str "https://localhost" ]
-                                    ]
-                                ]
-                            }
-                        , Task
-                            { status = Open
-                            , title = "todo"
-                            , assigned = []
-                            , description = []
-                            }
-                        ]
                     , mScore = Nothing
                     , updated = Nothing
-                    , priority = Nothing
                     }
                 ]
             }

--- a/md2jira/test/golden/demo.md-ast.golden
+++ b/md2jira/test/golden/demo.md-ast.golden
@@ -1,5 +1,5 @@
 Document
-    { config = EmptyConfig
+    { config = DocumentConfig { users = Nothing }
     , intro =
         [ Para
             [ Str "Document"
@@ -101,6 +101,7 @@ Document
                                 ]
                             ]
                         ]
+                    , assignee = Nothing
                     , points = Nothing
                     , updated = Nothing
                     }
@@ -135,6 +136,7 @@ Document
                                 ]
                             ]
                         ]
+                    , assignee = Nothing
                     , points = Nothing
                     , updated = Nothing
                     }

--- a/md2jira/test/golden/demo.md-ast.golden
+++ b/md2jira/test/golden/demo.md-ast.golden
@@ -42,6 +42,7 @@ Document
                 [ Story
                     { mJira = Nothing
                     , title = "Implement X"
+                    , status = Nothing
                     , description =
                         [ Para
                             [ Str "The"
@@ -100,12 +101,13 @@ Document
                                 ]
                             ]
                         ]
-                    , mScore = Nothing
+                    , points = Nothing
                     , updated = Nothing
                     }
                 , Story
                     { mJira = Nothing
                     , title = "Implement Z"
+                    , status = Nothing
                     , description =
                         [ BulletList
                             [
@@ -133,7 +135,7 @@ Document
                                 ]
                             ]
                         ]
-                    , mScore = Nothing
+                    , points = Nothing
                     , updated = Nothing
                     }
                 ]

--- a/md2jira/test/golden/demo.md-jira.golden
+++ b/md2jira/test/golden/demo.md-jira.golden
@@ -19,11 +19,9 @@ what about:
 * ☐ z task
 
 
-
 StoryTitle: Implement Z
 StoryBody:
 * ☒ completed
 bq. https://localhost
 * ☐ todo
-
 

--- a/md2jira/test/golden/local.md-ast.golden
+++ b/md2jira/test/golden/local.md-ast.golden
@@ -1,5 +1,5 @@
 Document
-    { config = EmptyConfig
+    { config = DocumentConfig { users = Nothing }
     , intro =
         [ Para
             [ Str "This"
@@ -30,6 +30,7 @@ Document
                             , Str "is..."
                             ]
                         ]
+                    , assignee = Nothing
                     , points = Nothing
                     , updated = Nothing
                     }

--- a/md2jira/test/golden/local.md-ast.golden
+++ b/md2jira/test/golden/local.md-ast.golden
@@ -20,6 +20,7 @@ Document
                 [ Story
                     { mJira = Nothing
                     , title = "Implement X"
+                    , status = Nothing
                     , description =
                         [ Para
                             [ Str "The"
@@ -29,7 +30,7 @@ Document
                             , Str "is..."
                             ]
                         ]
-                    , mScore = Nothing
+                    , points = Nothing
                     , updated = Nothing
                     }
                 ]

--- a/md2jira/test/golden/local.md-ast.golden
+++ b/md2jira/test/golden/local.md-ast.golden
@@ -1,5 +1,5 @@
 Document
-    { kind = AssignedStories "user@corp"
+    { config = EmptyConfig
     , intro =
         [ Para
             [ Str "This"
@@ -20,7 +20,6 @@ Document
                 [ Story
                     { mJira = Nothing
                     , title = "Implement X"
-                    , assigned = []
                     , description =
                         [ Para
                             [ Str "The"
@@ -30,10 +29,8 @@ Document
                             , Str "is..."
                             ]
                         ]
-                    , tasks = []
                     , mScore = Nothing
                     , updated = Nothing
-                    , priority = Nothing
                     }
                 ]
             }

--- a/md2jira/test/golden/local.md-jira.golden
+++ b/md2jira/test/golden/local.md-jira.golden
@@ -6,4 +6,3 @@ StoryTitle: Implement X
 StoryBody:
 The goal is...
 
-

--- a/md2jira/test/golden/local.md-round.golden
+++ b/md2jira/test/golden/local.md-round.golden
@@ -1,7 +1,3 @@
----
-assigned: user@corp
----
-
 This is my backlog.
 
 # Develop app

--- a/md2jira/test/golden/tasks.md-ast.golden
+++ b/md2jira/test/golden/tasks.md-ast.golden
@@ -1,5 +1,5 @@
 Document
-    { kind = FullBacklog
+    { config = EmptyConfig
     , intro = []
     , epics =
         [ Epic
@@ -10,7 +10,6 @@ Document
                 [ Story
                     { mJira = Nothing
                     , title = "story"
-                    , assigned = []
                     , description =
                         [ BulletList
                             [
@@ -86,49 +85,8 @@ Document
                                 ]
                             ]
                         ]
-                    , tasks =
-                        [ Task
-                            { status = Open
-                            , title = "a task"
-                            , assigned = []
-                            , description =
-                                [ Plain
-                                    [ Str "with"
-                                    , Space
-                                    , Str "left"
-                                    , Space
-                                    , Str "over"
-                                    ]
-                                ]
-                            }
-                        , Task
-                            { status = Open
-                            , title = "a task"
-                            , assigned = []
-                            , description =
-                                [ Plain
-                                    [ Str "with"
-                                    , Space
-                                    , Str "right"
-                                    ]
-                                ]
-                            }
-                        , Task
-                            { status = Open
-                            , title = "a task"
-                            , assigned = []
-                            , description = []
-                            }
-                        , Task
-                            { status = Open
-                            , title = "a task"
-                            , assigned = []
-                            , description = []
-                            }
-                        ]
                     , mScore = Nothing
                     , updated = Nothing
-                    , priority = Nothing
                     }
                 ]
             }

--- a/md2jira/test/golden/tasks.md-ast.golden
+++ b/md2jira/test/golden/tasks.md-ast.golden
@@ -10,6 +10,7 @@ Document
                 [ Story
                     { mJira = Nothing
                     , title = "story"
+                    , status = Nothing
                     , description =
                         [ BulletList
                             [
@@ -85,7 +86,7 @@ Document
                                 ]
                             ]
                         ]
-                    , mScore = Nothing
+                    , points = Nothing
                     , updated = Nothing
                     }
                 ]

--- a/md2jira/test/golden/tasks.md-ast.golden
+++ b/md2jira/test/golden/tasks.md-ast.golden
@@ -1,5 +1,5 @@
 Document
-    { config = EmptyConfig
+    { config = DocumentConfig { users = Nothing }
     , intro = []
     , epics =
         [ Epic
@@ -86,6 +86,7 @@ Document
                                 ]
                             ]
                         ]
+                    , assignee = Nothing
                     , points = Nothing
                     , updated = Nothing
                     }

--- a/md2jira/test/golden/tasks.md-jira.golden
+++ b/md2jira/test/golden/tasks.md-jira.golden
@@ -16,4 +16,3 @@ bq. with comment
 * ☐ a task
 bq. with comment
 
-

--- a/src/Jira.hs
+++ b/src/Jira.hs
@@ -282,6 +282,9 @@ updateIssue client jid issueData = ensureNull <$> jiraRequest client ("issue/" <
         [ "summary" .= T.strip issueData.summary
         , "description" .= T.strip issueData.description
         ]
+            <> case issueData.assignee of
+                Just name -> ["assignee" .= object ["name" .= name]]
+                Nothing -> []
 
 -- | From https://www.haskellforall.com/2021/05/the-trick-to-avoid-deeply-nested-error.html
 orDie :: Maybe a -> b -> Either b a


### PR DESCRIPTION
This change simplifies the md2jira implementation and improves the usage for local backlog update.